### PR TITLE
Cryptography Library Typo

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,4 +1,4 @@
 requests
 furl
 PyQt6
-cryptography
+pycryptodome


### PR DESCRIPTION
I accidentally put `cryptography` instead of `pycryptodome`